### PR TITLE
add runtimeSDK

### DIFF
--- a/src/main/kotlin/net/bytedance/security/app/AnalyzeStepByStep.kt
+++ b/src/main/kotlin/net/bytedance/security/app/AnalyzeStepByStep.kt
@@ -36,7 +36,7 @@ import kotlin.io.path.pathString
 import kotlin.streams.toList
 
 class AnalyzeStepByStep {
-    suspend fun loadRules(ruleList: String, targetSdk: Int): Rules {
+    suspend fun loadRules(ruleList: String, targetSdk: Int, minSdk: Int): Rules {
         val rulePathList = if (ruleList.isNotEmpty())
             ruleList.split(",").map { "${getConfig().rulePath}/${it.trim()}" }.toList()
         else
@@ -45,7 +45,7 @@ class AnalyzeStepByStep {
             }.filter { it.pathString.endsWith(".json") }.map { it.pathString }
                 .toList()
         val rules = Rules(rulePathList, RuleFactory())
-        rules.loadRules(targetSdk)
+        rules.loadRules(targetSdk, minSdk)
         return rules
     }
 

--- a/src/main/kotlin/net/bytedance/security/app/RuleData.kt
+++ b/src/main/kotlin/net/bytedance/security/app/RuleData.kt
@@ -125,7 +125,8 @@ data class RuleData(
     val ConstNumberMode: Boolean? = null,
     val targetNumberArr: List<Int>? = null,
 
-    val targetSdk: String = "",
+    val targetSdk: String = "",     // 规则适用的targetSdk版本
+    val runtimeSdk: String = "",    // 规则适用的运行时系统版本
 )
 
 val defaultSourceReturn = SourceReturn()

--- a/src/main/kotlin/net/bytedance/security/app/StaticAnalyzeMain.kt
+++ b/src/main/kotlin/net/bytedance/security/app/StaticAnalyzeMain.kt
@@ -54,11 +54,10 @@ object StaticAnalyzeMain {
         profiler.parseApk.end()
 
         profiler.preProcessor.start()
-        val rules = v3.loadRules(argumentConfig.rules, AndroidUtils.TargetSdk)
+        val rules = v3.loadRules(argumentConfig.rules, AndroidUtils.TargetSdk, AndroidUtils.MinSdk)
         logInfo("rules loaded")
         val ctx = v3.createContext(rules)
         profiler.preProcessor.end()
-
 
         if (getConfig().doWholeProcessMode) {
             PLUtils.createWholeProgramAnalyze(ctx)

--- a/src/main/kotlin/net/bytedance/security/app/rules/Rules.kt
+++ b/src/main/kotlin/net/bytedance/security/app/rules/Rules.kt
@@ -92,40 +92,39 @@ class Rules(val rulePaths: List<String>, val factory: IRuleFactory) : IRulesForC
                         throw Exception("read config file $path failed")
                     }
                 }
-
             return jsonStr
         }
-    }
 
-    private fun parseSdkVersion(input: String): List<Int> {
-        val MIN_SDK_VERSION = 9     // Android 2.3
-        val MAX_SDK_VERSION = 50    // for future
+        fun parseSdkVersion(input: String): List<Int> {
+            val MIN_SDK_VERSION = 9     // Android 2.3
+            val MAX_SDK_VERSION = 50    // for future
 
-        if (input.isBlank() || input.trim() == ":") {
-            return (MIN_SDK_VERSION..MAX_SDK_VERSION).toList()
-        }
-        return input.split(Regex("[,\\s]+")).flatMap { part ->
-            when {
-                part.contains(":") -> {
-                    val splitPart = part.split(":")
-                    val hasStart = splitPart[0].isNotEmpty()
-                    val hasEnd = splitPart[1].isNotEmpty()
-                    when {
-                        !hasStart && !hasEnd -> listOf()
-                        !hasEnd -> {
-                            (splitPart[0].toIntOrNull() ?: return@flatMap listOf())..MAX_SDK_VERSION
-                        }
-                        !hasStart -> {
-                            (MIN_SDK_VERSION..(splitPart[1].toIntOrNull() ?: return@flatMap listOf())).toList()
-                        }
-                        else -> {
-                            val start = splitPart[0].toIntOrNull() ?: return@flatMap listOf()
-                            val end = splitPart[1].toIntOrNull() ?: return@flatMap listOf()
-                            (start..end).toList()
+            if (input.isBlank() || input.trim() == ":") {
+                return (MIN_SDK_VERSION..MAX_SDK_VERSION).toList()
+            }
+            return input.split(Regex("[,\\s]+")).flatMap { part ->
+                when {
+                    part.contains(":") -> {
+                        val splitPart = part.split(":")
+                        val hasStart = splitPart[0].isNotEmpty()
+                        val hasEnd = splitPart[1].isNotEmpty()
+                        when {
+                            !hasStart && !hasEnd -> listOf()
+                            !hasEnd -> {
+                                (splitPart[0].toIntOrNull() ?: return@flatMap listOf())..MAX_SDK_VERSION
+                            }
+                            !hasStart -> {
+                                (MIN_SDK_VERSION..(splitPart[1].toIntOrNull() ?: return@flatMap listOf())).toList()
+                            }
+                            else -> {
+                                val start = splitPart[0].toIntOrNull() ?: return@flatMap listOf()
+                                val end = splitPart[1].toIntOrNull() ?: return@flatMap listOf()
+                                (start..end).toList()
+                            }
                         }
                     }
+                    else -> listOf(part.toIntOrNull() ?: return@flatMap listOf())
                 }
-                else -> listOf(part.toIntOrNull() ?: return@flatMap listOf())
             }
         }
     }

--- a/src/main/kotlin/net/bytedance/security/app/rules/Rules.kt
+++ b/src/main/kotlin/net/bytedance/security/app/rules/Rules.kt
@@ -29,8 +29,9 @@ import java.nio.file.Paths
 
 class Rules(val rulePaths: List<String>, val factory: IRuleFactory) : IRulesForContext {
     val allRules: MutableList<IRule> = ArrayList()
+    val UNLIMITED = -1
 
-    suspend fun loadRules(targetSdk: Int, minSdk: Int) {
+    suspend fun loadRules(targetSdk: Int = UNLIMITED, minSdk: Int = UNLIMITED) {
         rulePaths.forEach {
             val jsonStr = loadConfigOrQuit(it)
             val rules = Json.parseToJsonElement(jsonStr)
@@ -40,8 +41,8 @@ class Rules(val rulePaths: List<String>, val factory: IRuleFactory) : IRulesForC
                     ruleData.sanitize = ruleData.sanitizer
                     ruleData.sanitizer = null
                 }
-                if ((targetSdk == -1 || targetSdk in parseSdkVersion(ruleData.targetSdk)) &&
-                    (minSdk == -1 || parseSdkVersion("$minSdk:").any { it in parseSdkVersion(ruleData.runtimeSdk) })) {
+                if ((targetSdk == UNLIMITED || targetSdk in parseSdkVersion(ruleData.targetSdk)) &&
+                    (minSdk == UNLIMITED || parseSdkVersion("$minSdk:").any { it in parseSdkVersion(ruleData.runtimeSdk) })) {
                     val rule = factory.create(ruleName, ruleData)
                     allRules.add(rule)
                 } else {

--- a/src/test/kotlin/net/bytedance/security/app/rules/RulesTest.kt
+++ b/src/test/kotlin/net/bytedance/security/app/rules/RulesTest.kt
@@ -20,10 +20,10 @@ package net.bytedance.security.app.rules
 import kotlinx.coroutines.runBlocking
 import net.bytedance.security.app.getConfig
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
 import java.io.File
 
 internal class RulesTest {
-
 
     fun createDefaultRules(): Rules {
         val rules = Rules(
@@ -69,7 +69,22 @@ internal class RulesTest {
         println("const strings=${rules.constStringPatterns().toSortedSet().toList()}")
         println("fields=${rules.fields().toSortedSet().toList()}")
         println("new instances=${rules.newInstances().toSortedSet().toList()}")
+    }
 
+    @Test
+    fun testParseSdkVersion() {
+        assertEquals(
+            (9..50).toList(),
+            Rules.parseSdkVersion("")
+        )
+        assertEquals(
+            (9..50).toList(),
+            Rules.parseSdkVersion(":")
+        )
+        assertEquals(
+            (9..10).toList() + listOf(15) + (25..30).toList() + (45..50).toList(),
+            Rules.parseSdkVersion(":10, 15, 25:30, 45:")
+        )
     }
 
     companion object {


### PR DESCRIPTION
Android版本更新对App的影响分为两种情况：第一种是影响所有安装到该版本上的App；第二种是影响targetSdkVersion升级到该版本的App。
targetSDK字段影响的是第二种情况，现在引入新字段runtimeSDK来处理第一种情况，当runtimeSDK小于应用的minSDK时，即应用无法在该系统版本上运行，判断漏洞不存在。