### PR TITLE
feat(rules): add ARouter intent-redirection rule to detect WebView taint flow (refs #73)

### DIFF
--- a/config/rules/ARouterIntentRedirection.json
+++ b/config/rules/ARouterIntentRedirection.json
@@ -1,0 +1,60 @@
+{
+  "ARouterIntentRedirection": {
+    "enable": true,
+    "SliceMode": true,
+    "traceDepth": 8,
+    "desc": {
+      "name": "ARouterIntentRedirection",
+      "category": "IntentRedirection",
+      "detail": "Detects taint flowing from an exported component's Intent extras through Alibaba ARouter (com.alibaba.android.arouter) Postcard navigation into WebView.loadUrl. Tracks the chain reported in issue #73: Intent.getStringExtra -> Postcard.withString(...) -> ARouter.navigation() -> Bundle.getString(WEB_URL) -> WebView.loadUrl, which today causes Appshark to lose the taint chain at the ARouter boundary and report the WebView loadUrl call as a clean sink.",
+      "wiki": "https://github.com/bytedance/appshark/issues/73",
+      "possibility": "3",
+      "model": "high"
+    },
+    "entry": {},
+    "source": {
+      "Return": [
+        "<android.content.Intent: java.lang.String getStringExtra(java.lang.String)>",
+        "<android.content.Intent: android.os.Parcelable getParcelable*(java.lang.String)>",
+        "<android.content.Intent: android.net.Uri getData()>",
+        "<android.os.Bundle: java.lang.String getString(java.lang.String)>",
+        "<android.os.Bundle: java.lang.String getString(java.lang.String,java.lang.String)>"
+      ]
+    },
+    "sink": {
+      "<com.alibaba.android.arouter.facade.Postcard: com.alibaba.android.arouter.facade.Postcard withString(java.lang.String,java.lang.String)>": {
+        "TaintCheck": [
+          "p1"
+        ]
+      },
+      "<com.alibaba.android.arouter.facade.Postcard: com.alibaba.android.arouter.facade.Postcard withObject(java.lang.String,java.lang.Object)>": {
+        "TaintCheck": [
+          "p1"
+        ]
+      },
+      "<com.alibaba.android.arouter.facade.Postcard: com.alibaba.android.arouter.facade.Postcard with(android.os.Bundle)>": {
+        "TaintCheck": [
+          "p0"
+        ]
+      },
+      "<android.webkit.WebView: void loadUrl(java.lang.String)>": {
+        "LibraryOnly": false,
+        "TaintCheck": [
+          "p0"
+        ]
+      },
+      "<android.webkit.WebView: void loadUrl(java.lang.String,java.util.Map)>": {
+        "LibraryOnly": false,
+        "TaintCheck": [
+          "p0"
+        ]
+      },
+      "<android.webkit.WebView: void postUrl(java.lang.String,byte[])>": {
+        "LibraryOnly": false,
+        "TaintCheck": [
+          "p0"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Detect ARouter-mediated intent redirection into WebView.loadUrl (refs #73)

### Problem

Issue #73 documents a real-world taint chain that Appshark
currently misses:

```
LoginActivity (exported)
    -> HomeActivity
    -> ARouter.getInstance().build(WEB_ACTIVITY)
                            .withString(WEB_URL, attackerControlled)
                            .navigation()
    -> DemoWebActivity.initView()
         mUrl = getIntent().getStringExtra(WEB_URL)
         loadUrl(mUrl)
```

Appshark's existing `IntentRedirectionBabyVersion` rule does
not model `Postcard.withString` / `Postcard.withObject` /
`Postcard.with(Bundle)` as taint sinks, so the moment the URL
is handed to ARouter the taint vanishes and the eventual
`WebView.loadUrl` is reported as benign.

### Fix

Add a new rule file
`config/rules/ARouterIntentRedirection.json` that:

* Lists the three usual intent / bundle taint sources
  (`Intent.getStringExtra`, `Intent.getParcelable*`,
  `Intent.getData`, `Bundle.getString`).
* Lists the three ARouter `Postcard` data-binding APIs as
  taint sinks so the trace continues across the routing
  boundary instead of dropping there.
* Lists `WebView.loadUrl(String)`,
  `WebView.loadUrl(String, Map)` and `WebView.postUrl` as
  the eventual user-visible sink.

The rule follows the same JSON shape as the existing
`IntentRedirectionBabyVersion.json` and is picked up
automatically because the default `rulePath` in `config.json5`
is `config/rules` (i.e. all `*.json` in that directory).

### Why a separate rule file

Existing `IntentRedirectionBabyVersion.json` is intentionally
library-only and minimal. Folding ARouter sinks into it would
either widen its scope unexpectedly (it would start firing on
every ARouter call site, including safe ones) or require a
second rule key in the same file. A standalone rule keeps the
scope explicit and lets users disable just the ARouter rule
via the existing `enable: false` toggle if they do not use
ARouter in the app under analysis.

### Verification

Re-running Appshark against the demo APK described in #73
with this rule active reports the ARouter-mediated flow as
an `IntentRedirection / ARouterIntentRedirection` finding
with the full source -> ARouter -> sink trace.
